### PR TITLE
Генерация кошельков для Cairo 1.0

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -27,7 +27,7 @@ async function generateArgentWallet() {
     	const childNode = masterNode.derivePath(`m/44'/9004'/0'/0/0`)
 	const privateKey = `0x${ec.starkCurve.grindKey(childNode.privateKey)}`
 	const publicKey = ec.starkCurve.getStarkKey(privateKey);
-	const constructorcallData = CallData.compile({ owner: ec.starkCurve.getStarkKey(privateKey), guardian: 0})
+	const constructorCallData = CallData.compile({ owner: ec.starkCurve.getStarkKey(privateKey), guardian: 0})
 
 	const contractAddress = hash.calculateContractAddressFromHash(publicKey, argentXaccountClassHash, constructorCallData, 0)
 

--- a/generator.js
+++ b/generator.js
@@ -21,20 +21,15 @@ async function generateArgentWallet() {
 	const provider = new Provider({ sequencer: { network: constants.NetworkName.SN_GOERLI } });
 	const wallet = Wallet.createRandom();
 
-	const argentXaccountClassHash = "0x033434ad846cdd5f23eb73ff09fe6fddd568284a0fb7d1be20ee482f044dabe2";
-	const argentXproxyClassHash = "0x25ec026985a3bf9d0cc1fe17326b245dfdc3ff89b8fde106542a3ea56c5a918";
+	const argentXaccountClassHash = "0x1a736d6ed154502257f02b1ccdf4d9d1089f80811cd6acad48e6b6a9d1f2003";
 	
 	const masterNode = ethers.HDNodeWallet.fromSeed(toBeHex(BigInt(wallet.privateKey)))
-    const childNode = masterNode.derivePath(`m/44'/9004'/0'/0/0`)
+    	const childNode = masterNode.derivePath(`m/44'/9004'/0'/0/0`)
 	const privateKey = `0x${ec.starkCurve.grindKey(childNode.privateKey)}`
 	const publicKey = ec.starkCurve.getStarkKey(privateKey);
-	const constructorCallData = CallData.compile({
-		implementation: argentXaccountClassHash,
-		selector: hash.getSelectorFromName('initialize'),
-		calldata: CallData.compile({ signer: publicKey, guardian: '0' })
-	});
+	const constructorcallData = CallData.compile({ owner: ec.starkCurve.getStarkKey(privateKey), guardian: 0})
 
-	const contractAddress = hash.calculateContractAddressFromHash(publicKey, argentXproxyClassHash, constructorCallData, 0)
+	const contractAddress = hash.calculateContractAddressFromHash(publicKey, argentXaccountClassHash, constructorCallData, 0)
 
 	csvData.push({
 		address: wallet.address,


### PR DESCRIPTION
Обновление для генерации адресов новой версии ArgentX Account v0.3.0.

Если вписывать в расширение сгенерированные кошельки из старой версии данного ПО – в кошельке отображаются другие адреса (хоть мнемоника и приватный ключ остаются те же).

После обновления до Cairo 1.0 кошелёк ArgentX изменил шаблон и class hash для кошельков, новый class hash – [тык!](https://starkscan.co/class/0x01a736d6ed154502257f02b1ccdf4d9d1089f80811cd6acad48e6b6a9d1f2003), также слегка поменялись данные для генерации.